### PR TITLE
Refactor epsilon computation

### DIFF
--- a/prv_accountant/accountant.py
+++ b/prv_accountant/accountant.py
@@ -91,7 +91,7 @@ class Accountant:
 
     def compute_delta(self, f_n: DiscretePrivacyRandomVariable, epsilon: float) -> float:
         t = f_n.domain.ts()
-        return np.where(t >= epsilon, f_n.pmf*(1.0 - np.exp(epsilon)*np.exp(-t)), 0.0).sum()
+        return float(np.where(t >= epsilon, f_n.pmf*(1.0 - np.exp(epsilon)*np.exp(-t)), 0.0).sum())
 
     def compute_epsilon(self, num_compositions: int) -> Tuple[float, float, float]:
         """

--- a/prv_accountant/accountant.py
+++ b/prv_accountant/accountant.py
@@ -90,11 +90,8 @@ class Accountant:
         return self.compute_delta(f_n, epsilon+self.eps_error)-self.delta_error
 
     def compute_delta(self, f_n: DiscretePrivacyRandomVariable, epsilon: float) -> float:
-        delta = 0.0
-        for t_i, p_n_i in zip(f_n.domain, f_n.pmf):
-            if t_i >= epsilon:
-                delta += p_n_i*(1.0 - np.exp(epsilon)*np.exp(-t_i))
-        return np.float64(delta)
+        t = f_n.domain.ts()
+        return np.where(t >= epsilon, f_n.pmf*(1.0 - np.exp(epsilon)*np.exp(-t)), 0.0).sum()
 
     def compute_epsilon(self, num_compositions: int) -> Tuple[float, float, float]:
         """
@@ -106,9 +103,4 @@ class Accountant:
                                            upper bound of true epsilon
         """
         f_n = self.composer.compute_composition(num_compositions=num_compositions)
-        eps_lower = optimize.root_scalar(
-            lambda e: self.compute_delta_lower(f_n, e) - self.delta, bracket=(0, f_n.domain.t_max())).root
-        eps_upper = optimize.root_scalar(
-            lambda e: self.compute_delta_upper(f_n, e) - self.delta, bracket=(0, f_n.domain.t_max())).root
-        eps_avg = 0.5*(eps_lower+eps_upper)
-        return eps_lower, eps_avg, eps_upper
+        return f_n.compute_epsilon(self.delta, self.delta_error, self.eps_error)

--- a/prv_accountant/discrete_privacy_random_variable.py
+++ b/prv_accountant/discrete_privacy_random_variable.py
@@ -15,3 +15,21 @@ class DiscretePrivacyRandomVariable:
     def __len__(self) -> int:
         assert len(self.pmf) == len(self.domain)
         return len(self.pmf)
+
+    def compute_epsilon(self, delta, delta_error, epsilon_error):
+        t = self.domain.ts()
+        p = self.pmf
+        d1 = np.flip(np.flip(p).cumsum())
+        d2 = np.flip(np.flip(p*np.exp(-t)).cumsum())
+        ndelta = np.exp(t) * d2-d1
+
+        def find_epsilon(delta_target):
+            i = np.searchsorted(ndelta, -delta_target, side='left')
+            if i <= 0:
+                raise RuntimeError("Cannot compute epsilon")
+            return np.log((d1[i-1]-delta_target)/d2[i-1])
+       
+        eps_upper = find_epsilon(delta - delta_error) + epsilon_error
+        eps_lower = find_epsilon(delta + delta_error) - epsilon_error
+        eps_estimate = find_epsilon(delta)
+        return eps_lower, eps_estimate, eps_upper

--- a/prv_accountant/discrete_privacy_random_variable.py
+++ b/prv_accountant/discrete_privacy_random_variable.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 
 from .domain import Domain
 
+from typing import Tuple
+
 
 @dataclass
 class DiscretePrivacyRandomVariable:
@@ -16,7 +18,7 @@ class DiscretePrivacyRandomVariable:
         assert len(self.pmf) == len(self.domain)
         return len(self.pmf)
 
-    def compute_epsilon(self, delta, delta_error, epsilon_error):
+    def compute_epsilon(self, delta: float, delta_error: float, epsilon_error: float) -> Tuple[float, float, float]:
         t = self.domain.ts()
         p = self.pmf
         d1 = np.flip(np.flip(p).cumsum())
@@ -32,4 +34,4 @@ class DiscretePrivacyRandomVariable:
         eps_upper = find_epsilon(delta - delta_error) + epsilon_error
         eps_lower = find_epsilon(delta + delta_error) - epsilon_error
         eps_estimate = find_epsilon(delta)
-        return eps_lower, eps_estimate, eps_upper
+        return float(eps_lower), float(eps_estimate), float(eps_upper)

--- a/prv_accountant/privacy_random_variables.py
+++ b/prv_accountant/privacy_random_variables.py
@@ -88,20 +88,11 @@ class PoissonSubsampledGaussianMechanism(PrivacyRandomVariable):
     def cdf(self, t):
         sigma = self.sigma
         p = self.p
-        return np.where(t > 0, (
-                (1.0/2.0) * p *
-                (-erfc(np.float64((1.0/4.0)*M_SQRT2*(2*pow(sigma, 2) *
-                                                     (t + log((p + exp(t) - 1)*exp(-t)/p)) - 1)/sigma))) -
-                1.0/2.0*(p - 1) *
-                (-erfc(np.float64((1.0/4.0)*M_SQRT2*(2*pow(sigma, 2) *
-                                  (t + log((p + exp(t) - 1)*exp(-t)/p)) + 1)/sigma))) + 1
-            ), np.where(t > log(1 - p), (
-                (1.0/2.0) * p *
-                (-erfc(np.float64((1.0/4.0)*M_SQRT2*(2*pow(sigma, 2)*log((p + exp(t) - 1)/p) - 1)/sigma))) -
-                1.0/2.0*(p - 1) *
-                (-erfc(np.float64((1.0/4.0)*M_SQRT2*(2*pow(sigma, 2)*log((p + exp(t) - 1)/p) + 1)/sigma))) + 1
+        z = np.where(t>0, log((p-1)/p + exp(t)/p), log((p-1)/p + exp(t)/p))
+        return np.where(t > log(1 - p), (
+                (1.0/2.0) * p * (-erfc(np.float64((1.0/4.0)*M_SQRT2*(2*pow(sigma, 2)*z - 1)/sigma))) -
+                1.0/2.0*(p - 1) * (-erfc(np.float64((1.0/4.0)*M_SQRT2*(2*pow(sigma, 2)*z + 1)/sigma))) + 1
             ), 0.0)
-        )
 
     def mean(self):
         raise NotImplementedError("Mean computation not implemented")


### PR DESCRIPTION
Refactor computation of epsilon(delta). We now compute epsilon(delta) in a single pass and don't need the root finding operation any more. We also refactor the cdf computation slightly removing one where clause.