### PR TITLE
Improved conversion from RDP to Approximate DP

### DIFF
--- a/prv_accountant/other_accountants.py
+++ b/prv_accountant/other_accountants.py
@@ -37,7 +37,7 @@ class RDP:
         if len(orders_vec) != len(rdp_vec):
             raise ValueError("Input lists must have the same length.")
 
-        eps = rdp_vec - np.log(self.delta) / (orders_vec - 1)
+        eps = rdp_vec - np.log(self.delta * orders_vec) / (orders_vec - 1) + np.log1p(- 1 / orders_vec)
 
         idx_opt = np.nanargmin(eps)  # Ignore NaNs
         eps_opt = eps[idx_opt]


### PR DESCRIPTION
Use the improved conversion from RDP to (epsilon, delta)-DP in Theorem 21 of https://arxiv.org/abs/1905.09982v2. This is weaker than the optimal conversion in Lemma 1 of https://arxiv.org/abs/2001.05990v1, but equivalent for practical purposes.

This is the same conversion used in Opacus and TF Privacy. See
https://github.com/pytorch/opacus/blob/main/opacus/privacy_analysis.py#L300
https://github.com/tensorflow/privacy/blob/master/tensorflow_privacy/privacy/analysis/rdp_accountant.py#L282