### PR TITLE
Add check to prevent small values of delta

### DIFF
--- a/prv_accountant/accountant.py
+++ b/prv_accountant/accountant.py
@@ -66,6 +66,10 @@ class Accountant:
             print("Initialising FDP accountant")
             print(f"Domain = {domain}")
 
+        if np.finfo(np.longdouble).eps*len(domain) > self.delta - self.delta_error:
+            raise ValueError("Floating point errors will dominate for such small values of delta. "
+                             "Increase delta or reduce domain size.")
+
         prv_trunc = PrivacyRandomVariableTruncated(prv, domain.t_min(), domain.t_max())
 
         self.f_0 = discretisers.CellCentred().discretise(prv_trunc, domain)

--- a/prv_accountant/accountant.py
+++ b/prv_accountant/accountant.py
@@ -66,10 +66,6 @@ class Accountant:
             print("Initialising FDP accountant")
             print(f"Domain = {domain}")
 
-        if np.finfo(np.longdouble).eps*len(domain) > self.delta - self.delta_error:
-            raise ValueError("Floating point errors will dominate for such small values of delta. "
-                             "Increase delta or reduce domain size.")
-
         prv_trunc = PrivacyRandomVariableTruncated(prv, domain.t_min(), domain.t_max())
 
         self.f_0 = discretisers.CellCentred().discretise(prv_trunc, domain)

--- a/prv_accountant/discrete_privacy_random_variable.py
+++ b/prv_accountant/discrete_privacy_random_variable.py
@@ -19,6 +19,10 @@ class DiscretePrivacyRandomVariable:
         return len(self.pmf)
 
     def compute_epsilon(self, delta: float, delta_error: float, epsilon_error: float) -> Tuple[float, float, float]:
+        if np.finfo(np.longdouble).eps*len(self.domain) > delta - delta_error:
+            raise ValueError("Floating point errors will dominate for such small values of delta. "
+                             "Increase delta or reduce domain size.")
+
         t = self.domain.ts()
         p = self.pmf
         d1 = np.flip(np.flip(p).cumsum())

--- a/tests/test_accountant.py
+++ b/tests/test_accountant.py
@@ -31,7 +31,6 @@ class TestAccountant:
         assert delta_upper == pytest.approx(delta_exact, rel=1e-3)
         assert delta_lower == pytest.approx(delta_exact, rel=1e-3)
 
-<<<<<<< HEAD
     def test_throw_error_small_delta(self):
         with pytest.raises(ValueError):
             accountant = Accountant(
@@ -43,7 +42,6 @@ class TestAccountant:
             )
             accountant.compute_epsilon(1000)
 
-=======
     def test_invariance_max_compositions(self):
         noise_multiplier = 0.9
         sampling_probability = 256/100000
@@ -65,4 +63,3 @@ class TestAccountant:
                 eps_error=0.1
             ).compute_epsilon(4900)[2]
             assert eps_hi == pytest.approx(eps_hi_target, 1e-3)
->>>>>>> main

--- a/tests/test_accountant.py
+++ b/tests/test_accountant.py
@@ -30,3 +30,14 @@ class TestAccountant:
         delta_exact = compute_delta_exact(4, 10000, 100.0)
         assert delta_upper == pytest.approx(delta_exact, rel=1e-3)
         assert delta_lower == pytest.approx(delta_exact, rel=1e-3)
+
+    def test_throw_error_small_delta(self):
+        with pytest.raises(ValueError):
+            accountant = Accountant(
+                noise_multiplier=4,
+                sampling_probability=0.00038,
+                delta=1.13e-18,
+                eps_error=0.01,
+                max_compositions=10000
+            )
+

--- a/tests/test_accountant.py
+++ b/tests/test_accountant.py
@@ -40,4 +40,5 @@ class TestAccountant:
                 eps_error=0.01,
                 max_compositions=10000
             )
+            accountant.compute_epsilon(1000)
 


### PR DESCRIPTION
Add a check which raises an error if too small values of delta are requested. For small values of delta floating point issues may arise.