### PR TITLE
Add assertion to make domain creation meets requirements

### DIFF
--- a/prv_accountant/domain.py
+++ b/prv_accountant/domain.py
@@ -38,11 +38,13 @@ class Domain:
         """
         t_min = np.floor(t_min/dt)*dt
         t_max = np.ceil(t_max/dt)*dt
-        size = int((t_max-t_min)/dt) + 1
+        size = int(np.round((t_max-t_min)/dt)) + 1
         if size % 2 == 1:
             size += 1
             t_max += dt
-        return Domain(t_min, t_max, size)
+        d = Domain(t_min, t_max, size)
+        assert np.abs(d.dt() - dt)/dt < 1e-8
+        return d
 
     def shifts(self) -> float:
         """Sum of all shifts that were applied to this domain"""

--- a/prv_accountant/other_accountants.py
+++ b/prv_accountant/other_accountants.py
@@ -37,7 +37,7 @@ class RDP:
         if len(orders_vec) != len(rdp_vec):
             raise ValueError("Input lists must have the same length.")
 
-        eps = rdp_vec - np.log(self.delta) / (orders_vec - 1)
+        eps = rdp_vec - np.log(self.delta * orders_vec) / (orders_vec - 1) + np.log1p(- 1 / orders_vec)
 
         idx_opt = np.nanargmin(eps)  # Ignore NaNs
         eps_opt = eps[idx_opt]

--- a/tests/test_accountant.py
+++ b/tests/test_accountant.py
@@ -30,3 +30,25 @@ class TestAccountant:
         delta_exact = compute_delta_exact(4, 10000, 100.0)
         assert delta_upper == pytest.approx(delta_exact, rel=1e-3)
         assert delta_lower == pytest.approx(delta_exact, rel=1e-3)
+
+    def test_invariance_max_compositions(self):
+        noise_multiplier = 0.9
+        sampling_probability = 256/100000
+        target_delta = 1e-5
+
+        eps_hi_target = Accountant(
+            noise_multiplier=noise_multiplier,
+            sampling_probability=sampling_probability,
+            delta=target_delta,
+            max_compositions=4900,
+            eps_error=0.1
+        ).compute_epsilon(4900)[2]
+        for m_c in range(4900, 5000):
+            eps_hi = Accountant(
+                noise_multiplier=noise_multiplier,
+                sampling_probability=sampling_probability,
+                delta=target_delta,
+                max_compositions=m_c,
+                eps_error=0.1
+            ).compute_epsilon(4900)[2]
+            assert eps_hi == pytest.approx(eps_hi_target, 1e-3)


### PR DESCRIPTION
Previously in some edge cases we could end up with a domain that is not of the correct mesh size. In this PR we first round so we compensate for floating point inaccuracies and we also add an assertion to make sure the domain has the correct mesh size.