### PR TITLE
fix: determine points for mean computation based on inputs

### DIFF
--- a/prv_accountant/privacy_random_variables/abstract_privacy_random_variable.py
+++ b/prv_accountant/privacy_random_variables/abstract_privacy_random_variable.py
@@ -53,7 +53,7 @@ class PrivacyRandomVariableTruncated:
         lower_exponent = int(np.log10(np.abs(self.t_min)))
         upper_exponent = int(np.log10(self.t_max))
         points = np.concatenate([[self.t_min], -np.logspace(start=lower_exponent, stop=-5, num=10), [0],
-                                 np.logspace(start=upper_exponent, stop=-5, num=10)[::-1], [self.t_max]])
+                                 np.logspace(start=-5, stop=upper_exponent, num=10), [self.t_max]])
         m = 0.0
         for L, R in zip(points[:-1], points[1:]):
             I, err = integrate.quad(self.cdf, L, R, limit=500)

--- a/prv_accountant/privacy_random_variables/abstract_privacy_random_variable.py
+++ b/prv_accountant/privacy_random_variables/abstract_privacy_random_variable.py
@@ -49,7 +49,11 @@ class PrivacyRandomVariableTruncated:
         self.remaining_mass = self.prv.cdf(t_max) - self.prv.cdf(t_min)
 
     def mean(self) -> float:
-        points = [self.t_min, -1e-1, -1e-2, -1e-3, -1e-4, -1e-5, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1, self.t_max]
+        # determine points based on t_min and t_max
+        lower_exponent = int(np.log10(np.abs(self.t_min)))
+        upper_exponent = int(np.log10(self.t_max))
+        points = np.concatenate([[self.t_min], -np.logspace(start=lower_exponent, stop=-5, num=10), [0],
+                                 np.logspace(start=upper_exponent, stop=-5, num=10)[::-1], [self.t_max]])
         m = 0.0
         for L, R in zip(points[:-1], points[1:]):
             I, err = integrate.quad(self.cdf, L, R, limit=500)


### PR DESCRIPTION
Hi,

this PR should solve #36 , https://github.com/pytorch/opacus/issues/601 and https://github.com/pytorch/opacus/issues/604.

The cause of these errors seems to be that grid for computing the  `mean()` function of the `PrivacyRandomVariableTruncated` class. The grid (`points` variable) used to compute the mean is constant apart from the lowest (`self.t_min`) and highest point (`self.t_max`). 

This PR determines the grid (`points` variable)  based on the lowest and highest point. More information is below.

I ran the existing tests and they passed and wondered if there is need for more testing here.  @wulu473 said that  `In general, adding any additional points is safe and won't affect the robustness negatively.`

Best

-------------------------------------

**Observation**

I debugged the code and arrived at some point at the `mean()` function of the `PrivacyRandomVariableTruncated` class. The grid (`points` variable) used to compute the mean is constant apart from the lowest (`self.t_min`) and highest point (`self.t_max`). See the line of code [here](https://github.com/microsoft/prv_accountant/blob/a95c4e2d41ff4886c3e4a84925edf878a6540e0a/prv_accountant/privacy_random_variables/abstract_privacy_random_variable.py#L52). It looks like this `[self.tmin, -0.1, -0.01, -0.001, -0.0001, -1e-05, 1e-05, 0.0001, 0.001, 0.01, 0.1, self.tmax]`.

It seems that the `tmin` and `tmax` are of the order of `[-12,12]` for the examples that I posted above and even up to `[-48,48]` for the example that @jeandut posted in the https://github.com/pytorch/opacus/issues/604 issue whereas they are more like `[-7,7]` for the [readme example for DP-SGD](https://github.com/microsoft/prv_accountant#dp-sgd).

We suspect that the integration breaks down when the gridspacing between between `tmin` / `tmax` get's too large.

**Proposed solution**

Determine the points grid based on `tmin` and `tmax`. E.g., using this implementation that is inspired by [opacus implemenation](https://github.com/pytorch/opacus/blob/95df0904ae5d2b3aaa26b708e5067e9271624036/opacus/accountants/analysis/prv/prvs.py#L99-L106)  but determines the start and end of the logspace based on `tmin` and `tmax`.

```
lower_exponent = int(np.log10(np.abs(self.t_min)))
upper_exponent = int(np.log10(self.t_max))
points = np.concatenate([[self.t_min], -np.logspace(start=lower_exponent, stop=-5, num=10), [0],
                        np.logspace(start=upper_exponent, stop=-5, num=10)[::-1], [self.t_max]])
```

If I run this, I don't get the error anymore and the epsilon for the [readme example for DP-SGD](https://github.com/microsoft/prv_accountant#dp-sgd) is identical.
